### PR TITLE
changed é to e to workaround a puppet utf bug

### DIFF
--- a/Modulefile
+++ b/Modulefile
@@ -1,6 +1,6 @@
 name    'dalen-dnsquery'
 version '0.1.1'
-author 'Erik Dalén <erik.gustav.dalen@gmail.com>'
+author 'Erik Dalen <erik.gustav.dalen@gmail.com>'
 license 'Expat License'
 summary 'Query functions for DNS'
 project_page 'https://github.com/dalen/puppet-dnsquery'


### PR DESCRIPTION
Explained here https://github.com/dalen/puppet-dnsquery/issues/4
