### PR TITLE
Add dns_rlookup function.

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,10 @@ array will be an array of hashes containing a `preference` & `exchange` key.
 
 Retrieves DNS PTR records and returns it as an array of strings.
 
+### dns_rlookup
+
+Performs a reverse lookup of all records for a given address, and returns results as an array of strings.
+
 ### dns_srv
 
 Retrieves DNS SRV records and returns it as an array. Each record in the

--- a/lib/puppet/functions/dnsquery/rlookup.rb
+++ b/lib/puppet/functions/dnsquery/rlookup.rb
@@ -1,0 +1,36 @@
+# frozen_string_literal: true
+
+# Retrieves results from DNS reverse lookup and returns it as an array.
+# Each record in the array will be a hostname.
+# An optional lambda can be given to return a default value in case the
+# lookup fails. The lambda will only be called if the lookup failed.
+Puppet::Functions.create_function(:'dnsquery::rlookup') do
+  dispatch :dns_rlookup do
+    param 'String', :address
+  end
+
+  dispatch :dns_rlookup_with_default do
+    param 'String', :address
+    block_param
+  end
+
+  def dns_rlookup(address)
+    addr = IPAddr.new(address)
+    Resolv::DNS.new.getresources(
+      addr.reverse, Resolv::DNS::Resource::IN::PTR
+    ).map do |res|
+      res.name.to_s
+    end
+  end
+
+  def dns_rlookup_with_default(address)
+    ret = dns_rlookup(address)
+    if ret.empty?
+      yield
+    else
+      ret
+    end
+  rescue Resolv::ResolvError
+    yield
+  end
+end

--- a/spec/functions/dnsquery_rlookup_spec.rb
+++ b/spec/functions/dnsquery_rlookup_spec.rb
@@ -1,0 +1,21 @@
+#! /usr/bin/env ruby -S rspec
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+describe 'dnsquery::rlookup' do
+  it 'returns list of results from a reverse lookup' do
+    results = subject.execute('8.8.4.4')
+    expect(results).to be_a Array
+    expect(results).to all(be_a(String))
+  end
+
+  it 'returns lambda value if result is empty' do
+    is_expected.to(
+      run.
+      with_params('0.0.0.0').
+      and_return('foo.example.com').
+      with_lambda { 'foo.example.com' }
+    )
+  end
+end


### PR DESCRIPTION
This function takes an IP address and transforms it into a PTR record
which is then looked up, hence performing a convenient reverse-lookup. 

This also solves the issue described in #41 , one can now just do something like:
```
dns_rlookup("8.8.4.4")
```
