### PR TITLE
TXT: join text records

### DIFF
--- a/REFERENCE.md
+++ b/REFERENCE.md
@@ -261,7 +261,7 @@ Retrieves DNS TXT records for a domain and return as an array.
 
 Retrieves DNS TXT records for a domain and return as an array.
 
-Returns: `Array[Array[String]]` The txt domain for a domain
+Returns: `Array[String]` The txt domain for a domain
 
 ##### `domain`
 

--- a/lib/puppet/functions/dnsquery/txt.rb
+++ b/lib/puppet/functions/dnsquery/txt.rb
@@ -8,14 +8,13 @@ Puppet::Functions.create_function(:'dnsquery::txt') do
   dispatch :dns_txt do
     param 'Stdlib::Fqdn', :domain
     optional_block_param :block
-    return_type 'Array[Array[String]]'
+    return_type 'Array[String]'
   end
 
   def dns_txt(domain)
     ret = Resolv::DNS.new.getresources(
       domain, Resolv::DNS::Resource::IN::TXT
-    ).map(&:strings)
-    # TODO: we should really do .map(&:join) above but it would be a breaking change
+    ).map(&:strings).map(&:join)
     block_given? && ret.empty? ? yield : ret
   rescue Resolv::ResolvError
     block_given? ? yield : raise

--- a/spec/functions/dnsquery_txt_spec.rb
+++ b/spec/functions/dnsquery_txt_spec.rb
@@ -4,19 +4,18 @@
 require 'spec_helper'
 
 describe 'dnsquery::txt' do
-  it 'returns a list of lists of strings when doing a lookup' do
+  it 'returns a list of strings when doing a lookup' do
     results = subject.execute('google.com')
     expect(results).to be_a Array
-    expect(results).to all(be_a(Array))
-    expect(results).to all(all(be_a(String)))
+    expect(results).to all(be_a(String))
   end
 
   it 'returns lambda value if result is empty' do
     is_expected.to(
       run.
       with_params('foo.example.com').
-      and_return([['foobar']]).
-      with_lambda { [['foobar']] }
+      and_return(['foobar']).
+      with_lambda { ['foobar'] }
     )
   end
 end


### PR DESCRIPTION
TXT records that are larger then [255 characters are split into chunks](https://kb.isc.org/docs/aa-00356). This means that the result of a TXT record is always Array[Array[String]].

This 255 character limit is more a detail about DNS which is not very useful when presenting data to higher interfaces. as such join the inner elements so we have a more normalise Array[String] return_type

This is a backwards incompatible breaking change

