### PR TITLE
config_info: Allow users to override the resolver config

### DIFF
--- a/REFERENCE.md
+++ b/REFERENCE.md
@@ -19,6 +19,7 @@
 
 ### Data types
 
+* [`Dnsquery::Config_info`](#Dnsquery--Config_info): Type to validate the config_info passed to Resolve::DNS.new
 * [`Dnsquery::Mx`](#Dnsquery--Mx): type used for DNS MX records
 * [`Dnsquery::Soa`](#Dnsquery--Soa): type used for DNS SOA records
 * [`Dnsquery::Srv`](#Dnsquery--Srv): type used for DNS SRV records
@@ -31,7 +32,7 @@ Type: Ruby 4.x API
 
 Retrieves DNS A records for a domain and returns them as an array.
 
-#### `dnsquery::a(Stdlib::Fqdn $domain, Optional[Callable] &$block)`
+#### `dnsquery::a(Stdlib::Fqdn $domain, Optional[Dnsquery::Config_info] $config_info, Optional[Callable] &$block)`
 
 Retrieves DNS A records for a domain and returns them as an array.
 
@@ -42,6 +43,12 @@ Returns: `Array[Stdlib::IP::Address::V4::Nosubnet]` An array of A answers matchi
 Data type: `Stdlib::Fqdn`
 
 the dns domain to lookup
+
+##### `config_info`
+
+Data type: `Optional[Dnsquery::Config_info]`
+
+used to override the config for Resolve::DNS.new
 
 ##### `&block`
 
@@ -55,7 +62,7 @@ Type: Ruby 4.x API
 
 Retrieves DNS AAAA records for a domain and them it as an array.
 
-#### `dnsquery::aaaa(Stdlib::Fqdn $domain, Optional[Callable] &$block)`
+#### `dnsquery::aaaa(Stdlib::Fqdn $domain, Optional[Dnsquery::Config_info] $config_info, Optional[Callable] &$block)`
 
 Retrieves DNS AAAA records for a domain and them it as an array.
 
@@ -66,6 +73,12 @@ Returns: `Array[Stdlib::IP::Address::V6::Nosubnet]` An array of AAAA records mat
 Data type: `Stdlib::Fqdn`
 
 the dns domain to lookup
+
+##### `config_info`
+
+Data type: `Optional[Dnsquery::Config_info]`
+
+used to override the config for Resolve::DNS.new
 
 ##### `&block`
 
@@ -79,7 +92,7 @@ Type: Ruby 4.x API
 
 Retrieves a DNS CNAME record for a domain and returns it as a string.
 
-#### `dnsquery::cname(Stdlib::Fqdn $domain, Optional[Callable] &$block)`
+#### `dnsquery::cname(Stdlib::Fqdn $domain, Optional[Dnsquery::Config_info] $config_info, Optional[Callable] &$block)`
 
 Retrieves a DNS CNAME record for a domain and returns it as a string.
 
@@ -90,6 +103,12 @@ Returns: `String` An string representing the CNAME of a domain
 Data type: `Stdlib::Fqdn`
 
 the dns domain to lookup
+
+##### `config_info`
+
+Data type: `Optional[Dnsquery::Config_info]`
+
+used to override the config for Resolve::DNS.new
 
 ##### `&block`
 
@@ -105,7 +124,7 @@ Do a DNS lookup and returns an array of addresses.
 This will follow CNAMEs and return any matching IPv4 or IPv6 addresses.
 See the more specific functions if you only want one type returned.
 
-#### `dnsquery::lookup(Stdlib::Fqdn $domain, Optional[Boolean] $force_ipv6, Optional[Callable] &$block)`
+#### `dnsquery::lookup(Stdlib::Fqdn $domain, Optional[Boolean] $force_ipv6, Optional[Dnsquery::Config_info] $config_info, Optional[Callable] &$block)`
 
 Do a DNS lookup and returns an array of addresses.
 This will follow CNAMEs and return any matching IPv4 or IPv6 addresses.
@@ -125,6 +144,12 @@ Data type: `Optional[Boolean]`
 
 ensure we get AAAA answers even if the requestor has no global ipv6 address
 
+##### `config_info`
+
+Data type: `Optional[Dnsquery::Config_info]`
+
+used to override the config for Resolve::DNS.new
+
 ##### `&block`
 
 Data type: `Optional[Callable]`
@@ -137,7 +162,7 @@ Type: Ruby 4.x API
 
 Retrieves DNS MX records for a domain and returns them as an array.
 
-#### `dnsquery::mx(Stdlib::Fqdn $domain, Optional[Callable] &$block)`
+#### `dnsquery::mx(Stdlib::Fqdn $domain, Optional[Dnsquery::Config_info] $config_info, Optional[Callable] &$block)`
 
 Retrieves DNS MX records for a domain and returns them as an array.
 
@@ -148,6 +173,12 @@ Returns: `Array[Dnsquery::Mx]` An array of hashes representing the mx records fo
 Data type: `Stdlib::Fqdn`
 
 the dns domain to lookup
+
+##### `config_info`
+
+Data type: `Optional[Dnsquery::Config_info]`
+
+used to override the config for Resolve::DNS.new
 
 ##### `&block`
 
@@ -161,7 +192,7 @@ Type: Ruby 4.x API
 
 Retrieves DNS PTR records for a domain and returns them as an array.
 
-#### `dnsquery::ptr(Stdlib::Fqdn $domain, Optional[Callable] &$block)`
+#### `dnsquery::ptr(Stdlib::Fqdn $domain, Optional[Dnsquery::Config_info] $config_info, Optional[Callable] &$block)`
 
 Retrieves DNS PTR records for a domain and returns them as an array.
 
@@ -172,6 +203,12 @@ Returns: `Array[Stdlib::Fqdn]` An array of PTR answeres matching domain
 Data type: `Stdlib::Fqdn`
 
 the dns domain to lookup
+
+##### `config_info`
+
+Data type: `Optional[Dnsquery::Config_info]`
+
+used to override the config for Resolve::DNS.new
 
 ##### `&block`
 
@@ -185,7 +222,7 @@ Type: Ruby 4.x API
 
 Retrieves results from DNS reverse lookup and returns it as an array.
 
-#### `dnsquery::rlookup(Stdlib::IP::Address::Nosubnet $address, Optional[Callable] &$block)`
+#### `dnsquery::rlookup(Stdlib::IP::Address::Nosubnet $address, Optional[Dnsquery::Config_info] $config_info, Optional[Callable] &$block)`
 
 Retrieves results from DNS reverse lookup and returns it as an array.
 
@@ -196,6 +233,12 @@ Returns: `Array[Stdlib::Fqdn]` An array of hostnames matching the ip address
 Data type: `Stdlib::IP::Address::Nosubnet`
 
 the ip address to lookup
+
+##### `config_info`
+
+Data type: `Optional[Dnsquery::Config_info]`
+
+used to override the config for Resolve::DNS.new
 
 ##### `&block`
 
@@ -209,7 +252,7 @@ Type: Ruby 4.x API
 
 Retrieves DNS SOA records and returns it as a hash.
 
-#### `dnsquery::soa(Stdlib::Fqdn $question, Optional[Callable] &$block)`
+#### `dnsquery::soa(Stdlib::Fqdn $question, Optional[Dnsquery::Config_info] $config_info, Optional[Callable] &$block)`
 
 Retrieves DNS SOA records and returns it as a hash.
 
@@ -220,6 +263,12 @@ Returns: `Dnsquery::Soa` The SOA record matching domain
 Data type: `Stdlib::Fqdn`
 
 the dns question to lookup
+
+##### `config_info`
+
+Data type: `Optional[Dnsquery::Config_info]`
+
+used to override the config for Resolve::DNS.new
 
 ##### `&block`
 
@@ -233,7 +282,7 @@ Type: Ruby 4.x API
 
 Retirve the SRV domain for a specific domain
 
-#### `dnsquery::srv(String $domain, Optional[Callable] &$block)`
+#### `dnsquery::srv(String $domain, Optional[Dnsquery::Config_info] $config_info, Optional[Callable] &$block)`
 
 Retirve the SRV domain for a specific domain
 
@@ -244,6 +293,12 @@ Returns: `Array[Dnsquery::Srv]` The srv records for domain as an array of hashs
 Data type: `String`
 
 the dns question to lookup
+
+##### `config_info`
+
+Data type: `Optional[Dnsquery::Config_info]`
+
+used to override the config for Resolve::DNS.new
 
 ##### `&block`
 
@@ -257,7 +312,7 @@ Type: Ruby 4.x API
 
 Retrieves DNS TXT records for a domain and return as an array.
 
-#### `dnsquery::txt(Stdlib::Fqdn $domain, Optional[Callable] &$block)`
+#### `dnsquery::txt(Stdlib::Fqdn $domain, Optional[Dnsquery::Config_info] $config_info, Optional[Callable] &$block)`
 
 Retrieves DNS TXT records for a domain and return as an array.
 
@@ -269,6 +324,12 @@ Data type: `Stdlib::Fqdn`
 
 the dns question to lookup
 
+##### `config_info`
+
+Data type: `Optional[Dnsquery::Config_info]`
+
+used to override the config for Resolve::DNS.new
+
 ##### `&block`
 
 Data type: `Optional[Callable]`
@@ -276,6 +337,20 @@ Data type: `Optional[Callable]`
 an optional lambda to return a default value in case the lookup fails
 
 ## Data types
+
+### <a name="Dnsquery--Config_info"></a>`Dnsquery::Config_info`
+
+Type to validate the config_info passed to Resolve::DNS.new
+
+Alias of
+
+```puppet
+Struct[{
+  'nameserver'       => Variant[Stdlib::IP::Address::Nosubnet, Array[Stdlib::IP::Address::Nosubnet]],
+  Optional['search'] => Array[Stdlib::Fqdn],
+  Optional['ndots']  => Integer[1,63],
+}]
+```
 
 ### <a name="Dnsquery--Mx"></a>`Dnsquery::Mx`
 

--- a/lib/puppet/functions/dnsquery/a.rb
+++ b/lib/puppet/functions/dnsquery/a.rb
@@ -1,18 +1,23 @@
 # frozen_string_literal: true
 
+require_relative '../../../puppet_x/voxpupuli/dnsquery/util'
+
 # Retrieves DNS A records for a domain and returns them as an array.
 Puppet::Functions.create_function(:'dnsquery::a') do
   # @param domain the dns domain to lookup
+  # @param config_info used to override the config for Resolve::DNS.new
   # @param block an optional lambda to return a default value in case the lookup fails
   # @return An array of A answers matching domain
   dispatch :dns_a do
     param 'Stdlib::Fqdn', :domain
+    optional_param 'Dnsquery::Config_info', :config_info
     optional_block_param :block
     return_type 'Array[Stdlib::IP::Address::V4::Nosubnet]'
   end
 
-  def dns_a(domain)
-    ret = Resolv::DNS.new.getresources(
+  def dns_a(domain, config_info = nil)
+    resolver = PuppetX::Voxpupuli::Dnsquery::Utils.resolver(config_info)
+    ret = resolver.getresources(
       domain, Resolv::DNS::Resource::IN::A
     ).map do |res|
       res.address.to_s

--- a/lib/puppet/functions/dnsquery/aaaa.rb
+++ b/lib/puppet/functions/dnsquery/aaaa.rb
@@ -1,18 +1,23 @@
 # frozen_string_literal: true
 
+require_relative '../../../puppet_x/voxpupuli/dnsquery/util'
+
 # Retrieves DNS AAAA records for a domain and them it as an array.
 Puppet::Functions.create_function(:'dnsquery::aaaa') do
   # @param domain the dns domain to lookup
+  # @param config_info used to override the config for Resolve::DNS.new
   # @param block an optional lambda to return a default value in case the lookup fails
   # @return An array of AAAA records matching domain
   dispatch :dns_aaaa do
     param 'Stdlib::Fqdn', :domain
+    optional_param 'Dnsquery::Config_info', :config_info
     optional_block_param :block
     return_type 'Array[Stdlib::IP::Address::V6::Nosubnet]'
   end
 
-  def dns_aaaa(domain)
-    ret = Resolv::DNS.new.getresources(
+  def dns_aaaa(domain, config_info = nil)
+    resolver = PuppetX::Voxpupuli::Dnsquery::Utils.resolver(config_info)
+    ret = resolver.getresources(
       domain, Resolv::DNS::Resource::IN::AAAA
     ).map do |res|
       IPAddr.new(res.address.to_s).to_s

--- a/lib/puppet/functions/dnsquery/cname.rb
+++ b/lib/puppet/functions/dnsquery/cname.rb
@@ -1,18 +1,23 @@
 # frozen_string_literal: true
 
+require_relative '../../../puppet_x/voxpupuli/dnsquery/util'
+
 # Retrieves a DNS CNAME record for a domain and returns it as a string.
 Puppet::Functions.create_function(:'dnsquery::cname') do
   # @param domain the dns domain to lookup
+  # @param config_info used to override the config for Resolve::DNS.new
   # @param block an optional lambda to return a default value in case the lookup fails
   # @return An string representing the CNAME of a domain
   dispatch :dns_cname do
     param 'Stdlib::Fqdn', :domain
+    optional_param 'Dnsquery::Config_info', :config_info
     optional_block_param :block
     return_type 'String'
   end
 
-  def dns_cname(domain)
-    Resolv::DNS.new.getresource(
+  def dns_cname(domain, config_info = nil)
+    resolver = PuppetX::Voxpupuli::Dnsquery::Utils.resolver(config_info)
+    resolver.getresource(
       domain, Resolv::DNS::Resource::IN::CNAME
     ).name.to_s
   rescue Resolv::ResolvError

--- a/lib/puppet/functions/dnsquery/lookup.rb
+++ b/lib/puppet/functions/dnsquery/lookup.rb
@@ -1,25 +1,30 @@
 # frozen_string_literal: true
 
+require_relative '../../../puppet_x/voxpupuli/dnsquery/util'
+
 # Do a DNS lookup and returns an array of addresses.
 # This will follow CNAMEs and return any matching IPv4 or IPv6 addresses.
 # See the more specific functions if you only want one type returned.
 Puppet::Functions.create_function(:'dnsquery::lookup') do
   # @param domain the dns domain to lookup
   # @param force_ipv6 ensure we get AAAA answers even if the requestor has no global ipv6 address
+  # @param config_info used to override the config for Resolve::DNS.new
   # @param block an optional lambda to return a default value in case the lookup fails
   # @return An array of A and AAAA answers matching domain
   dispatch :dns_lookup do
     param 'Stdlib::Fqdn', :domain
     optional_param 'Boolean', :force_ipv6
+    optional_param 'Dnsquery::Config_info', :config_info
     optional_block_param :block
     return_type 'Array[Stdlib::IP::Address::Nosubnet]'
   end
 
-  def dns_lookup(domain, force_ipv6 = false)
+  def dns_lookup(domain, force_ipv6 = false, config_info = nil)
+    resolver = PuppetX::Voxpupuli::Dnsquery::Utils.resolver(config_info)
     ret = if force_ipv6
-            call_function('dnsquery::a', domain) + call_function('dnsquery::aaaa', domain)
+            call_function('dnsquery::a', domain, config_info) + call_function('dnsquery::aaaa', domain, config_info)
           else
-            Resolv::DNS.new.getaddresses(domain).map(&:to_s)
+            resolver.getaddresses(domain).map(&:to_s)
           end
     block_given? && ret.empty? ? yield : ret
   rescue Resolv::ResolvError

--- a/lib/puppet/functions/dnsquery/mx.rb
+++ b/lib/puppet/functions/dnsquery/mx.rb
@@ -1,18 +1,23 @@
 # frozen_string_literal: true
 
+require_relative '../../../puppet_x/voxpupuli/dnsquery/util'
+
 # Retrieves DNS MX records for a domain and returns them as an array.
 Puppet::Functions.create_function(:'dnsquery::mx') do
   # @param domain the dns domain to lookup
+  # @param config_info used to override the config for Resolve::DNS.new
   # @param block an optional lambda to return a default value in case the lookup fails
   # @return An array of hashes representing the mx records for domain
   dispatch :dns_mx do
     param 'Stdlib::Fqdn', :domain
+    optional_param 'Dnsquery::Config_info', :config_info
     optional_block_param :block
     return_type 'Array[Dnsquery::Mx]'
   end
 
-  def dns_mx(domain)
-    ret = Resolv::DNS.new.getresources(
+  def dns_mx(domain, config_info = nil)
+    resolver = PuppetX::Voxpupuli::Dnsquery::Utils.resolver(config_info)
+    ret = resolver.getresources(
       domain, Resolv::DNS::Resource::IN::MX
     ).map do |res|
       {

--- a/lib/puppet/functions/dnsquery/ptr.rb
+++ b/lib/puppet/functions/dnsquery/ptr.rb
@@ -1,18 +1,23 @@
 # frozen_string_literal: true
 
+require_relative '../../../puppet_x/voxpupuli/dnsquery/util'
+
 # Retrieves DNS PTR records for a domain and returns them as an array.
 Puppet::Functions.create_function(:'dnsquery::ptr') do
   # @param domain the dns domain to lookup
+  # @param config_info used to override the config for Resolve::DNS.new
   # @param block an optional lambda to return a default value in case the lookup fails
   # @return An array of PTR answeres matching domain
   dispatch :dns_ptr do
     param 'Stdlib::Fqdn', :domain
+    optional_param 'Dnsquery::Config_info', :config_info
     optional_block_param :block
     return_type 'Array[Stdlib::Fqdn]'
   end
 
-  def dns_ptr(domain)
-    ret = Resolv::DNS.new.getresources(
+  def dns_ptr(domain, config_info = nil)
+    resolver = PuppetX::Voxpupuli::Dnsquery::Utils.resolver(config_info)
+    ret = resolver.getresources(
       domain, Resolv::DNS::Resource::IN::PTR
     ).map do |res|
       res.name.to_s

--- a/lib/puppet/functions/dnsquery/rlookup.rb
+++ b/lib/puppet/functions/dnsquery/rlookup.rb
@@ -1,19 +1,24 @@
 # frozen_string_literal: true
 
+require_relative '../../../puppet_x/voxpupuli/dnsquery/util'
+
 # Retrieves results from DNS reverse lookup and returns it as an array.
 Puppet::Functions.create_function(:'dnsquery::rlookup') do
   # @param address the ip address to lookup
+  # @param config_info used to override the config for Resolve::DNS.new
   # @param block an optional lambda to return a default value in case the lookup fails
   # @return An array of hostnames matching the ip address
   dispatch :dns_rlookup do
     param 'Stdlib::IP::Address::Nosubnet', :address
+    optional_param 'Dnsquery::Config_info', :config_info
     optional_block_param :block
     return_type 'Array[Stdlib::Fqdn]'
   end
 
-  def dns_rlookup(address)
+  def dns_rlookup(address, config_info = nil)
+    resolver = PuppetX::Voxpupuli::Dnsquery::Utils.resolver(config_info)
     addr = IPAddr.new(address)
-    ret = Resolv::DNS.new.getresources(
+    ret = resolver.getresources(
       addr.reverse, Resolv::DNS::Resource::IN::PTR
     ).map do |res|
       res.name.to_s

--- a/lib/puppet/functions/dnsquery/soa.rb
+++ b/lib/puppet/functions/dnsquery/soa.rb
@@ -1,18 +1,23 @@
 # frozen_string_literal: true
 
+require_relative '../../../puppet_x/voxpupuli/dnsquery/util'
+
 # Retrieves DNS SOA records and returns it as a hash.
 Puppet::Functions.create_function(:'dnsquery::soa') do
   # @param question the dns question to lookup
+  # @param config_info used to override the config for Resolve::DNS.new
   # @param block an optional lambda to return a default value in case the lookup fails
   # @return The SOA record matching domain
   dispatch :dns_soa do
     param 'Stdlib::Fqdn', :question
+    optional_param 'Dnsquery::Config_info', :config_info
     optional_block_param :block
     return_type 'Dnsquery::Soa'
   end
 
-  def dns_soa(question)
-    res = Resolv::DNS.new.getresource(
+  def dns_soa(question, config_info = nil)
+    resolver = PuppetX::Voxpupuli::Dnsquery::Utils.resolver(config_info)
+    res = resolver.getresource(
       question, Resolv::DNS::Resource::IN::SOA
     )
     {

--- a/lib/puppet/functions/dnsquery/srv.rb
+++ b/lib/puppet/functions/dnsquery/srv.rb
@@ -1,19 +1,24 @@
 # frozen_string_literal: true
 
+require_relative '../../../puppet_x/voxpupuli/dnsquery/util'
+
 # Retirve the SRV domain for a specific domain
 Puppet::Functions.create_function(:'dnsquery::srv') do
   # @param domain the dns question to lookup
+  # @param config_info used to override the config for Resolve::DNS.new
   # @param block an optional lambda to return a default value in case the lookup fails
   # @return The srv records for domain as an array of hashs
   dispatch :dns_srv do
     # TODO: resurrect https://github.com/puppetlabs/puppetlabs-stdlib/pull/1230
     param 'String', :domain
+    optional_param 'Dnsquery::Config_info', :config_info
     optional_block_param :block
     return_type 'Array[Dnsquery::Srv]'
   end
 
-  def dns_srv(domain)
-    ret = Resolv::DNS.new.getresources(
+  def dns_srv(domain, config_info = nil)
+    resolver = PuppetX::Voxpupuli::Dnsquery::Utils.resolver(config_info)
+    ret = resolver.getresources(
       domain, Resolv::DNS::Resource::IN::SRV
     ).map do |res|
       {

--- a/lib/puppet/functions/dnsquery/txt.rb
+++ b/lib/puppet/functions/dnsquery/txt.rb
@@ -1,18 +1,23 @@
 # frozen_string_literal: true
 
+require_relative '../../../puppet_x/voxpupuli/dnsquery/util'
+
 # Retrieves DNS TXT records for a domain and return as an array.
 Puppet::Functions.create_function(:'dnsquery::txt') do
   # @param domain the dns question to lookup
+  # @param config_info used to override the config for Resolve::DNS.new
   # @param block an optional lambda to return a default value in case the lookup fails
   # @return The txt domain for a domain
   dispatch :dns_txt do
     param 'Stdlib::Fqdn', :domain
+    optional_param 'Dnsquery::Config_info', :config_info
     optional_block_param :block
     return_type 'Array[String]'
   end
 
-  def dns_txt(domain)
-    ret = Resolv::DNS.new.getresources(
+  def dns_txt(domain, config_info = nil)
+    resolver = PuppetX::Voxpupuli::Dnsquery::Utils.resolver(config_info)
+    ret = resolver.getresources(
       domain, Resolv::DNS::Resource::IN::TXT
     ).map(&:strings).map(&:join)
     block_given? && ret.empty? ? yield : ret

--- a/lib/puppet_x/voxpupuli/dnsquery/util.rb
+++ b/lib/puppet_x/voxpupuli/dnsquery/util.rb
@@ -1,0 +1,17 @@
+# frozen_string_literal: true
+
+module PuppetX
+  module Voxpupuli
+    module Dnsquery
+      module Utils
+        def self.resolver(config_info = nil)
+          if config_info
+            Resolv::DNS.new(config_info.transform_keys(&:to_sym))
+          else
+            Resolv::DNS.new
+          end
+        end
+      end
+    end
+  end
+end

--- a/spec/functions/dnsquery_a_spec.rb
+++ b/spec/functions/dnsquery_a_spec.rb
@@ -10,6 +10,24 @@ describe 'dnsquery::a' do
     expect(results).to all(match(%r{^[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}$}))
   end
 
+  it 'returns a list of IPv4 addresses when doing a lookup with updated namesrver' do
+    results = subject.execute('google.com', { 'nameserver' => '8.8.8.8' })
+    expect(results).to be_a Array
+    expect(results).to all(match(%r{^[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}$}))
+  end
+
+  it 'returns a list of IPv4 addresses when doing a lookup with updated ndots' do
+    results = subject.execute('google.com', { 'nameserver' => '8.8.8.8', 'ndots' => 1 })
+    expect(results).to be_a Array
+    expect(results).to all(match(%r{^[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}$}))
+  end
+
+  it 'returns a list of IPv4 addresses when doing a lookup with updated search' do
+    results = subject.execute('google', { 'nameserver' => '8.8.8.8', 'search' => ['com'] })
+    expect(results).to be_a Array
+    expect(results).to all(match(%r{^[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}$}))
+  end
+
   it 'returns lambda value if result is empty' do
     is_expected.to(
       run.

--- a/spec/functions/dnsquery_aaaa_spec.rb
+++ b/spec/functions/dnsquery_aaaa_spec.rb
@@ -2,14 +2,30 @@
 # frozen_string_literal: true
 
 require 'spec_helper'
-
+ipv6_pattern = %r{([0-9a-fA-F]{1,4}:){7,7}[0-9a-fA-F]{1,4}|([0-9a-fA-F]{1,4}:){1,7}:|([0-9a-fA-F]{1,4}:){1,6}:[0-9a-fA-F]{1,4}|([0-9a-fA-F]{1,4}:){1,5}(:[0-9a-fA-F]{1,4}){1,2}|([0-9a-fA-F]{1,4}:){1,4}(:[0-9a-fA-F]{1,4}){1,3}|([0-9a-fA-F]{1,4}:){1,3}(:[0-9a-fA-F]{1,4}){1,4}|([0-9a-fA-F]{1,4}:){1,2}(:[0-9a-fA-F]{1,4}){1,5}|[0-9a-fA-F]{1,4}:((:[0-9a-fA-F]{1,4}){1,6})|:((:[0-9a-fA-F]{1,4}){1,7}|:)|fe80:(:[0-9a-fA-F]{0,4}){0,4}%[0-9a-zA-Z]{1,}|::(ffff(:0{1,4}){0,1}:){0,1}((25[0-5]|(2[0-4]|1{0,1}[0-9]){0,1}[0-9])\.){3,3}(25[0-5]|(2[0-4]|1{0,1}[0-9]){0,1}[0-9])|([0-9a-fA-F]{1,4}:){1,4}:((25[0-5]|(2[0-4]|1{0,1}[0-9]){0,1}[0-9])\.){3,3}(25[0-5]|(2[0-4]|1{0,1}[0-9]){0,1}[0-9])}
 describe 'dnsquery::aaaa' do
   it 'returns a list of IPv6 addresses when doing a lookup' do
     results = subject.execute('google.com')
     expect(results).to be_a Array
-    expect(results).to all(
-      match(%r{([0-9a-fA-F]{1,4}:){7,7}[0-9a-fA-F]{1,4}|([0-9a-fA-F]{1,4}:){1,7}:|([0-9a-fA-F]{1,4}:){1,6}:[0-9a-fA-F]{1,4}|([0-9a-fA-F]{1,4}:){1,5}(:[0-9a-fA-F]{1,4}){1,2}|([0-9a-fA-F]{1,4}:){1,4}(:[0-9a-fA-F]{1,4}){1,3}|([0-9a-fA-F]{1,4}:){1,3}(:[0-9a-fA-F]{1,4}){1,4}|([0-9a-fA-F]{1,4}:){1,2}(:[0-9a-fA-F]{1,4}){1,5}|[0-9a-fA-F]{1,4}:((:[0-9a-fA-F]{1,4}){1,6})|:((:[0-9a-fA-F]{1,4}){1,7}|:)|fe80:(:[0-9a-fA-F]{0,4}){0,4}%[0-9a-zA-Z]{1,}|::(ffff(:0{1,4}){0,1}:){0,1}((25[0-5]|(2[0-4]|1{0,1}[0-9]){0,1}[0-9])\.){3,3}(25[0-5]|(2[0-4]|1{0,1}[0-9]){0,1}[0-9])|([0-9a-fA-F]{1,4}:){1,4}:((25[0-5]|(2[0-4]|1{0,1}[0-9]){0,1}[0-9])\.){3,3}(25[0-5]|(2[0-4]|1{0,1}[0-9]){0,1}[0-9])})
-    )
+    expect(results).to all(match(ipv6_pattern))
+  end
+
+  it 'returns a list of IPv6 addresses when doing a lookup with different nameserver' do
+    results = subject.execute('google.com', { 'nameserver' => '8.8.8.8' })
+    expect(results).to be_a Array
+    expect(results).to all(match(ipv6_pattern))
+  end
+
+  it 'returns a list of IPv6 addresses when doing a lookup with different ndots' do
+    results = subject.execute('google.com', { 'nameserver' => '8.8.8.8', 'ndots' => 1 })
+    expect(results).to be_a Array
+    expect(results).to all(match(ipv6_pattern))
+  end
+
+  it 'returns a list of IPv6 addresses when doing a lookup with different search' do
+    results = subject.execute('google', { 'nameserver' => '8.8.8.8', 'search' => ['com'] })
+    expect(results).to be_a Array
+    expect(results).to all(match(ipv6_pattern))
   end
 
   it 'returns lambda value if result is empty' do

--- a/spec/functions/dnsquery_cname_spec.rb
+++ b/spec/functions/dnsquery_cname_spec.rb
@@ -9,6 +9,21 @@ describe 'dnsquery::cname' do
     expect(result).to be_a String
   end
 
+  it 'returns a CNAME destination when doing a lookup update nameserver' do
+    result = subject.execute('en.wikipedia.org', { 'nameserver' => ['8.8.8.8'] })
+    expect(result).to be_a String
+  end
+
+  it 'returns a CNAME destination when doing a lookup with updated ndots' do
+    result = subject.execute('en.wikipedia.org', { 'nameserver' => '8.8.8.8', 'ndots' => 1 })
+    expect(result).to be_a String
+  end
+
+  it 'returns a CNAME destination when doing a lookup with updated search' do
+    result = subject.execute('en.wikipedia', { 'nameserver' => '8.8.8.8', 'search' => ['org'] })
+    expect(result).to be_a String
+  end
+
   it 'raises an error on empty reply' do
     is_expected.to run.
       with_params('foo.example.com').

--- a/spec/functions/dnsquery_lookup_spec.rb
+++ b/spec/functions/dnsquery_lookup_spec.rb
@@ -3,13 +3,31 @@
 
 require 'spec_helper'
 
+matcher = %r{^([0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}|([0-9a-fA-F]{1,4}:){7,7}[0-9a-fA-F]{1,4}|([0-9a-fA-F]{1,4}:){1,7}:|([0-9a-fA-F]{1,4}:){1,6}:[0-9a-fA-F]{1,4}|([0-9a-fA-F]{1,4}:){1,5}(:[0-9a-fA-F]{1,4}){1,2}|([0-9a-fA-F]{1,4}:){1,4}(:[0-9a-fA-F]{1,4}){1,3}|([0-9a-fA-F]{1,4}:){1,3}(:[0-9a-fA-F]{1,4}){1,4}|([0-9a-fA-F]{1,4}:){1,2}(:[0-9a-fA-F]{1,4}){1,5}|[0-9a-fA-F]{1,4}:((:[0-9a-fA-F]{1,4}){1,6})|:((:[0-9a-fA-F]{1,4}){1,7}|:)|fe80:(:[0-9a-fA-F]{0,4}){0,4}%[0-9a-zA-Z]{1,}|::(ffff(:0{1,4}){0,1}:){0,1}((25[0-5]|(2[0-4]|1{0,1}[0-9]){0,1}[0-9])\.){3,3}(25[0-5]|(2[0-4]|1{0,1}[0-9]){0,1}[0-9])|([0-9a-fA-F]{1,4}:){1,4}:((25[0-5]|(2[0-4]|1{0,1}[0-9]){0,1}[0-9])\.){3,3}(25[0-5]|(2[0-4]|1{0,1}[0-9]){0,1}[0-9]))$}
+
 describe 'dnsquery::lookup' do
   it 'returns a list of addresses when doing a lookup for a single record' do
     results = subject.execute('google.com')
     expect(results).to be_a Array
-    expect(results).to all(
-      match(%r{^([0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}|([0-9a-fA-F]{1,4}:){7,7}[0-9a-fA-F]{1,4}|([0-9a-fA-F]{1,4}:){1,7}:|([0-9a-fA-F]{1,4}:){1,6}:[0-9a-fA-F]{1,4}|([0-9a-fA-F]{1,4}:){1,5}(:[0-9a-fA-F]{1,4}){1,2}|([0-9a-fA-F]{1,4}:){1,4}(:[0-9a-fA-F]{1,4}){1,3}|([0-9a-fA-F]{1,4}:){1,3}(:[0-9a-fA-F]{1,4}){1,4}|([0-9a-fA-F]{1,4}:){1,2}(:[0-9a-fA-F]{1,4}){1,5}|[0-9a-fA-F]{1,4}:((:[0-9a-fA-F]{1,4}){1,6})|:((:[0-9a-fA-F]{1,4}){1,7}|:)|fe80:(:[0-9a-fA-F]{0,4}){0,4}%[0-9a-zA-Z]{1,}|::(ffff(:0{1,4}){0,1}:){0,1}((25[0-5]|(2[0-4]|1{0,1}[0-9]){0,1}[0-9])\.){3,3}(25[0-5]|(2[0-4]|1{0,1}[0-9]){0,1}[0-9])|([0-9a-fA-F]{1,4}:){1,4}:((25[0-5]|(2[0-4]|1{0,1}[0-9]){0,1}[0-9])\.){3,3}(25[0-5]|(2[0-4]|1{0,1}[0-9]){0,1}[0-9]))$})
-    )
+    expect(results).to all(match(matcher))
+  end
+
+  it 'returns a list of addresses when doing a lookup for a single record with update nameserver' do
+    results = subject.execute('google.com', true, { 'nameserver' => ['8.8.8.8'] })
+    expect(results).to be_a Array
+    expect(results).to all(match(matcher))
+  end
+
+  it 'returns a list of addresses when doing a lookup for a single record with update ndots' do
+    results = subject.execute('google.com', true, { 'nameserver' => '8.8.8.8', 'ndots' => 1 })
+    expect(results).to be_a Array
+    expect(results).to all(match(matcher))
+  end
+
+  it 'returns a list of addresses when doing a lookup for a single record with update search' do
+    results = subject.execute('google', true, { 'nameserver' => '8.8.8.8', 'search' => ['com'] })
+    expect(results).to be_a Array
+    expect(results).to all(match(matcher))
   end
 
   it 'returns lambda value if result is empty' do

--- a/spec/functions/dnsquery_mx_spec.rb
+++ b/spec/functions/dnsquery_mx_spec.rb
@@ -17,6 +17,36 @@ describe 'dnsquery::mx' do
     end
   end
 
+  it 'returns a list of MX records when doing a lookup with update nameserver' do
+    results = subject.execute('google.com', { 'nameserver' => ['8.8.8.8'] })
+    expect(results).to be_a Array
+    expect(results).to all(be_a(Hash))
+    results.each do |res|
+      expect(res['preference']).to be_a Integer
+      expect(res['exchange']).to be_a String
+    end
+  end
+
+  it 'returns a list of MX records when doing a lookup with update ndots' do
+    results = subject.execute('google.com', { 'nameserver' => '8.8.8.8', 'ndots' => 1 })
+    expect(results).to be_a Array
+    expect(results).to all(be_a(Hash))
+    results.each do |res|
+      expect(res['preference']).to be_a Integer
+      expect(res['exchange']).to be_a String
+    end
+  end
+
+  it 'returns a list of MX records when doing a lookup with update search' do
+    results = subject.execute('google', { 'nameserver' => '8.8.8.8', 'search' => ['com'] })
+    expect(results).to be_a Array
+    expect(results).to all(be_a(Hash))
+    results.each do |res|
+      expect(res['preference']).to be_a Integer
+      expect(res['exchange']).to be_a String
+    end
+  end
+
   it 'returns lambda value if result is empty' do
     is_expected.to(
       run.

--- a/spec/functions/dnsquery_ptr_spec.rb
+++ b/spec/functions/dnsquery_ptr_spec.rb
@@ -10,6 +10,24 @@ describe 'dnsquery::ptr' do
     expect(results).to all(be_a(String))
   end
 
+  it 'returns a list of PTR results when doing a lookup with update nameserver' do
+    results = subject.execute('8.8.8.8.in-addr.arpa', { 'nameserver' => ['8.8.8.8'] })
+    expect(results).to be_a Array
+    expect(results).to all(be_a(String))
+  end
+
+  it 'returns a list of PTR results when doing a lookup with update ndots' do
+    results = subject.execute('8.8.8.8.in-addr.arpa', { 'nameserver' => '8.8.8.8', 'ndots' => 1 })
+    expect(results).to be_a Array
+    expect(results).to all(be_a(String))
+  end
+
+  it 'returns a list of PTR results when doing a lookup with update search' do
+    results = subject.execute('8.8.8.8.in-addr', { 'nameserver' => '8.8.8.8', 'search' => ['arpa'] })
+    expect(results).to be_a Array
+    expect(results).to all(be_a(String))
+  end
+
   it 'returns lambda value if result is empty' do
     is_expected.to(
       run.

--- a/spec/functions/dnsquery_rlookup_spec.rb
+++ b/spec/functions/dnsquery_rlookup_spec.rb
@@ -10,6 +10,12 @@ describe 'dnsquery::rlookup' do
     expect(results).to all(be_a(String))
   end
 
+  it 'returns list of results from a reverse lookup with update nameserver' do
+    results = subject.execute('8.8.4.4', { 'nameserver' => '8.8.8.8' })
+    expect(results).to be_a Array
+    expect(results).to all(be_a(String))
+  end
+
   it 'returns lambda value if result is empty' do
     is_expected.to(
       run.

--- a/spec/functions/dnsquery_soa_spec.rb
+++ b/spec/functions/dnsquery_soa_spec.rb
@@ -23,6 +23,42 @@ describe 'dnsquery::soa' do
     expect(results['serial']).to be_a Integer
   end
 
+  it 'must return a hash of SOA-records parts when doing a lookup with update nameserver' do
+    results = subject.execute('google.com', { 'nameserver' => ['8.8.8.8'] })
+    expect(results).to be_a Hash
+    expect(results['expire']).to be_a Integer
+    expect(results['minimum']).to be_a Integer
+    expect(results['mname']).to be_a String
+    expect(results['refresh']).to be_a Integer
+    expect(results['retry']).to be_a Integer
+    expect(results['rname']).to be_a String
+    expect(results['serial']).to be_a Integer
+  end
+
+  it 'must return a hash of SOA-records parts when doing a lookup with update ndots' do
+    results = subject.execute('google.com', { 'nameserver' => '8.8.8.8', 'ndots' => 1 })
+    expect(results).to be_a Hash
+    expect(results['expire']).to be_a Integer
+    expect(results['minimum']).to be_a Integer
+    expect(results['mname']).to be_a String
+    expect(results['refresh']).to be_a Integer
+    expect(results['retry']).to be_a Integer
+    expect(results['rname']).to be_a String
+    expect(results['serial']).to be_a Integer
+  end
+
+  it 'must return a hash of SOA-records parts when doing a lookup with update search' do
+    results = subject.execute('google', { 'nameserver' => '8.8.8.8', 'search' => ['com'] })
+    expect(results).to be_a Hash
+    expect(results['expire']).to be_a Integer
+    expect(results['minimum']).to be_a Integer
+    expect(results['mname']).to be_a String
+    expect(results['refresh']).to be_a Integer
+    expect(results['retry']).to be_a Integer
+    expect(results['rname']).to be_a String
+    expect(results['serial']).to be_a Integer
+  end
+
   it 'returns lambda value if result is empty' do
     is_expected.to(
       run.

--- a/spec/functions/dnsquery_srv_spec.rb
+++ b/spec/functions/dnsquery_srv_spec.rb
@@ -21,6 +21,42 @@ describe 'dnsquery::srv' do
     end
   end
 
+  it 'returns a list of SRV records when doing a lookup with update nameserver' do
+    results = subject.execute('_spotify-client._tcp.spotify.com', { 'nameserver' => ['8.8.8.8'] })
+    expect(results).to be_a Array
+    expect(results).to all(be_a(Hash))
+    results.each do |res|
+      expect(res['priority']).to be_a Integer
+      expect(res['weight']).to be_a Integer
+      expect(res['port']).to be_a Integer
+      expect(res['target']).to be_a String
+    end
+  end
+
+  it 'returns a list of SRV records when doing a lookup with update ndots' do
+    results = subject.execute('_spotify-client._tcp.spotify.com', { 'nameserver' => '8.8.8.8', 'ndots' => 1 })
+    expect(results).to be_a Array
+    expect(results).to all(be_a(Hash))
+    results.each do |res|
+      expect(res['priority']).to be_a Integer
+      expect(res['weight']).to be_a Integer
+      expect(res['port']).to be_a Integer
+      expect(res['target']).to be_a String
+    end
+  end
+
+  it 'returns a list of SRV records when doing a lookup with update search' do
+    results = subject.execute('_spotify-client._tcp.spotify', { 'nameserver' => '8.8.8.8', 'search' => ['com'] })
+    expect(results).to be_a Array
+    expect(results).to all(be_a(Hash))
+    results.each do |res|
+      expect(res['priority']).to be_a Integer
+      expect(res['weight']).to be_a Integer
+      expect(res['port']).to be_a Integer
+      expect(res['target']).to be_a String
+    end
+  end
+
   it 'returns lambda value if result is empty' do
     is_expected.to(
       run.

--- a/spec/functions/dnsquery_txt_spec.rb
+++ b/spec/functions/dnsquery_txt_spec.rb
@@ -10,6 +10,24 @@ describe 'dnsquery::txt' do
     expect(results).to all(be_a(String))
   end
 
+  it 'returns a list of lists of strings when doing a lookup with update nameserver' do
+    results = subject.execute('google.com', { 'nameserver' => ['8.8.8.8'] })
+    expect(results).to be_a Array
+    expect(results).to all(be_a(String))
+  end
+
+  it 'returns a list of lists of strings when doing a lookup with update ndots' do
+    results = subject.execute('google.com', { 'nameserver' => '8.8.8.8', 'ndots' => 1 })
+    expect(results).to be_a Array
+    expect(results).to all(be_a(String))
+  end
+
+  it 'returns a list of lists of strings when doing a lookup with update search' do
+    results = subject.execute('google', { 'nameserver' => '8.8.8.8', 'search' => ['com'] })
+    expect(results).to be_a Array
+    expect(results).to all(be_a(String))
+  end
+
   it 'returns lambda value if result is empty' do
     is_expected.to(
       run.

--- a/types/config_info.pp
+++ b/types/config_info.pp
@@ -1,0 +1,6 @@
+# @summary Type to validate the config_info passed to Resolve::DNS.new
+type Dnsquery::Config_info = Struct[{
+  'nameserver'       => Variant[Stdlib::IP::Address::Nosubnet, Array[Stdlib::IP::Address::Nosubnet]],
+  Optional['search'] => Array[Stdlib::Fqdn],
+  Optional['ndots']  => Integer[1,63],
+}]


### PR DESCRIPTION
This PR allows useres to set the following:
 * nameservers
 * ndots
 * search

reimplements #10

