### PR TITLE
138: Allow nil value for config_info

### DIFF
--- a/REFERENCE.md
+++ b/REFERENCE.md
@@ -32,7 +32,7 @@ Type: Ruby 4.x API
 
 Retrieves DNS A records for a domain and returns them as an array.
 
-#### `dnsquery::a(Stdlib::Fqdn $domain, Optional[Dnsquery::Config_info] $config_info, Optional[Callable] &$block)`
+#### `dnsquery::a(Stdlib::Fqdn $domain, Optional[Optional[Dnsquery::Config_info]] $config_info, Optional[Callable] &$block)`
 
 Retrieves DNS A records for a domain and returns them as an array.
 
@@ -46,7 +46,7 @@ the dns domain to lookup
 
 ##### `config_info`
 
-Data type: `Optional[Dnsquery::Config_info]`
+Data type: `Optional[Optional[Dnsquery::Config_info]]`
 
 used to override the config for Resolve::DNS.new
 
@@ -62,7 +62,7 @@ Type: Ruby 4.x API
 
 Retrieves DNS AAAA records for a domain and them it as an array.
 
-#### `dnsquery::aaaa(Stdlib::Fqdn $domain, Optional[Dnsquery::Config_info] $config_info, Optional[Callable] &$block)`
+#### `dnsquery::aaaa(Stdlib::Fqdn $domain, Optional[Optional[Dnsquery::Config_info]] $config_info, Optional[Callable] &$block)`
 
 Retrieves DNS AAAA records for a domain and them it as an array.
 
@@ -76,7 +76,7 @@ the dns domain to lookup
 
 ##### `config_info`
 
-Data type: `Optional[Dnsquery::Config_info]`
+Data type: `Optional[Optional[Dnsquery::Config_info]]`
 
 used to override the config for Resolve::DNS.new
 
@@ -92,7 +92,7 @@ Type: Ruby 4.x API
 
 Retrieves a DNS CNAME record for a domain and returns it as a string.
 
-#### `dnsquery::cname(Stdlib::Fqdn $domain, Optional[Dnsquery::Config_info] $config_info, Optional[Callable] &$block)`
+#### `dnsquery::cname(Stdlib::Fqdn $domain, Optional[Optional[Dnsquery::Config_info]] $config_info, Optional[Callable] &$block)`
 
 Retrieves a DNS CNAME record for a domain and returns it as a string.
 
@@ -106,7 +106,7 @@ the dns domain to lookup
 
 ##### `config_info`
 
-Data type: `Optional[Dnsquery::Config_info]`
+Data type: `Optional[Optional[Dnsquery::Config_info]]`
 
 used to override the config for Resolve::DNS.new
 
@@ -124,7 +124,7 @@ Do a DNS lookup and returns an array of addresses.
 This will follow CNAMEs and return any matching IPv4 or IPv6 addresses.
 See the more specific functions if you only want one type returned.
 
-#### `dnsquery::lookup(Stdlib::Fqdn $domain, Optional[Boolean] $force_ipv6, Optional[Dnsquery::Config_info] $config_info, Optional[Callable] &$block)`
+#### `dnsquery::lookup(Stdlib::Fqdn $domain, Optional[Boolean] $force_ipv6, Optional[Optional[Dnsquery::Config_info]] $config_info, Optional[Callable] &$block)`
 
 Do a DNS lookup and returns an array of addresses.
 This will follow CNAMEs and return any matching IPv4 or IPv6 addresses.
@@ -146,7 +146,7 @@ ensure we get AAAA answers even if the requestor has no global ipv6 address
 
 ##### `config_info`
 
-Data type: `Optional[Dnsquery::Config_info]`
+Data type: `Optional[Optional[Dnsquery::Config_info]]`
 
 used to override the config for Resolve::DNS.new
 
@@ -162,7 +162,7 @@ Type: Ruby 4.x API
 
 Retrieves DNS MX records for a domain and returns them as an array.
 
-#### `dnsquery::mx(Stdlib::Fqdn $domain, Optional[Dnsquery::Config_info] $config_info, Optional[Callable] &$block)`
+#### `dnsquery::mx(Stdlib::Fqdn $domain, Optional[Optional[Dnsquery::Config_info]] $config_info, Optional[Callable] &$block)`
 
 Retrieves DNS MX records for a domain and returns them as an array.
 
@@ -176,7 +176,7 @@ the dns domain to lookup
 
 ##### `config_info`
 
-Data type: `Optional[Dnsquery::Config_info]`
+Data type: `Optional[Optional[Dnsquery::Config_info]]`
 
 used to override the config for Resolve::DNS.new
 
@@ -192,7 +192,7 @@ Type: Ruby 4.x API
 
 Retrieves DNS PTR records for a domain and returns them as an array.
 
-#### `dnsquery::ptr(Stdlib::Fqdn $domain, Optional[Dnsquery::Config_info] $config_info, Optional[Callable] &$block)`
+#### `dnsquery::ptr(Stdlib::Fqdn $domain, Optional[Optional[Dnsquery::Config_info]] $config_info, Optional[Callable] &$block)`
 
 Retrieves DNS PTR records for a domain and returns them as an array.
 
@@ -206,7 +206,7 @@ the dns domain to lookup
 
 ##### `config_info`
 
-Data type: `Optional[Dnsquery::Config_info]`
+Data type: `Optional[Optional[Dnsquery::Config_info]]`
 
 used to override the config for Resolve::DNS.new
 
@@ -222,7 +222,7 @@ Type: Ruby 4.x API
 
 Retrieves results from DNS reverse lookup and returns it as an array.
 
-#### `dnsquery::rlookup(Stdlib::IP::Address::Nosubnet $address, Optional[Dnsquery::Config_info] $config_info, Optional[Callable] &$block)`
+#### `dnsquery::rlookup(Stdlib::IP::Address::Nosubnet $address, Optional[Optional[Dnsquery::Config_info]] $config_info, Optional[Callable] &$block)`
 
 Retrieves results from DNS reverse lookup and returns it as an array.
 
@@ -236,7 +236,7 @@ the ip address to lookup
 
 ##### `config_info`
 
-Data type: `Optional[Dnsquery::Config_info]`
+Data type: `Optional[Optional[Dnsquery::Config_info]]`
 
 used to override the config for Resolve::DNS.new
 
@@ -252,7 +252,7 @@ Type: Ruby 4.x API
 
 Retrieves DNS SOA records and returns it as a hash.
 
-#### `dnsquery::soa(Stdlib::Fqdn $question, Optional[Dnsquery::Config_info] $config_info, Optional[Callable] &$block)`
+#### `dnsquery::soa(Stdlib::Fqdn $question, Optional[Optional[Dnsquery::Config_info]] $config_info, Optional[Callable] &$block)`
 
 Retrieves DNS SOA records and returns it as a hash.
 
@@ -266,7 +266,7 @@ the dns question to lookup
 
 ##### `config_info`
 
-Data type: `Optional[Dnsquery::Config_info]`
+Data type: `Optional[Optional[Dnsquery::Config_info]]`
 
 used to override the config for Resolve::DNS.new
 
@@ -282,7 +282,7 @@ Type: Ruby 4.x API
 
 Retirve the SRV domain for a specific domain
 
-#### `dnsquery::srv(String $domain, Optional[Dnsquery::Config_info] $config_info, Optional[Callable] &$block)`
+#### `dnsquery::srv(String $domain, Optional[Optional[Dnsquery::Config_info]] $config_info, Optional[Callable] &$block)`
 
 Retirve the SRV domain for a specific domain
 
@@ -296,7 +296,7 @@ the dns question to lookup
 
 ##### `config_info`
 
-Data type: `Optional[Dnsquery::Config_info]`
+Data type: `Optional[Optional[Dnsquery::Config_info]]`
 
 used to override the config for Resolve::DNS.new
 
@@ -312,7 +312,7 @@ Type: Ruby 4.x API
 
 Retrieves DNS TXT records for a domain and return as an array.
 
-#### `dnsquery::txt(Stdlib::Fqdn $domain, Optional[Dnsquery::Config_info] $config_info, Optional[Callable] &$block)`
+#### `dnsquery::txt(Stdlib::Fqdn $domain, Optional[Optional[Dnsquery::Config_info]] $config_info, Optional[Callable] &$block)`
 
 Retrieves DNS TXT records for a domain and return as an array.
 
@@ -326,7 +326,7 @@ the dns question to lookup
 
 ##### `config_info`
 
-Data type: `Optional[Dnsquery::Config_info]`
+Data type: `Optional[Optional[Dnsquery::Config_info]]`
 
 used to override the config for Resolve::DNS.new
 

--- a/lib/puppet/functions/dnsquery/a.rb
+++ b/lib/puppet/functions/dnsquery/a.rb
@@ -10,7 +10,7 @@ Puppet::Functions.create_function(:'dnsquery::a') do
   # @return An array of A answers matching domain
   dispatch :dns_a do
     param 'Stdlib::Fqdn', :domain
-    optional_param 'Dnsquery::Config_info', :config_info
+    optional_param 'Optional[Dnsquery::Config_info]', :config_info
     optional_block_param :block
     return_type 'Array[Stdlib::IP::Address::V4::Nosubnet]'
   end

--- a/lib/puppet/functions/dnsquery/aaaa.rb
+++ b/lib/puppet/functions/dnsquery/aaaa.rb
@@ -10,7 +10,7 @@ Puppet::Functions.create_function(:'dnsquery::aaaa') do
   # @return An array of AAAA records matching domain
   dispatch :dns_aaaa do
     param 'Stdlib::Fqdn', :domain
-    optional_param 'Dnsquery::Config_info', :config_info
+    optional_param 'Optional[Dnsquery::Config_info]', :config_info
     optional_block_param :block
     return_type 'Array[Stdlib::IP::Address::V6::Nosubnet]'
   end

--- a/lib/puppet/functions/dnsquery/cname.rb
+++ b/lib/puppet/functions/dnsquery/cname.rb
@@ -10,7 +10,7 @@ Puppet::Functions.create_function(:'dnsquery::cname') do
   # @return An string representing the CNAME of a domain
   dispatch :dns_cname do
     param 'Stdlib::Fqdn', :domain
-    optional_param 'Dnsquery::Config_info', :config_info
+    optional_param 'Optional[Dnsquery::Config_info]', :config_info
     optional_block_param :block
     return_type 'String'
   end

--- a/lib/puppet/functions/dnsquery/lookup.rb
+++ b/lib/puppet/functions/dnsquery/lookup.rb
@@ -14,7 +14,7 @@ Puppet::Functions.create_function(:'dnsquery::lookup') do
   dispatch :dns_lookup do
     param 'Stdlib::Fqdn', :domain
     optional_param 'Boolean', :force_ipv6
-    optional_param 'Dnsquery::Config_info', :config_info
+    optional_param 'Optional[Dnsquery::Config_info]', :config_info
     optional_block_param :block
     return_type 'Array[Stdlib::IP::Address::Nosubnet]'
   end

--- a/lib/puppet/functions/dnsquery/mx.rb
+++ b/lib/puppet/functions/dnsquery/mx.rb
@@ -10,7 +10,7 @@ Puppet::Functions.create_function(:'dnsquery::mx') do
   # @return An array of hashes representing the mx records for domain
   dispatch :dns_mx do
     param 'Stdlib::Fqdn', :domain
-    optional_param 'Dnsquery::Config_info', :config_info
+    optional_param 'Optional[Dnsquery::Config_info]', :config_info
     optional_block_param :block
     return_type 'Array[Dnsquery::Mx]'
   end

--- a/lib/puppet/functions/dnsquery/ptr.rb
+++ b/lib/puppet/functions/dnsquery/ptr.rb
@@ -10,7 +10,7 @@ Puppet::Functions.create_function(:'dnsquery::ptr') do
   # @return An array of PTR answeres matching domain
   dispatch :dns_ptr do
     param 'Stdlib::Fqdn', :domain
-    optional_param 'Dnsquery::Config_info', :config_info
+    optional_param 'Optional[Dnsquery::Config_info]', :config_info
     optional_block_param :block
     return_type 'Array[Stdlib::Fqdn]'
   end

--- a/lib/puppet/functions/dnsquery/rlookup.rb
+++ b/lib/puppet/functions/dnsquery/rlookup.rb
@@ -10,7 +10,7 @@ Puppet::Functions.create_function(:'dnsquery::rlookup') do
   # @return An array of hostnames matching the ip address
   dispatch :dns_rlookup do
     param 'Stdlib::IP::Address::Nosubnet', :address
-    optional_param 'Dnsquery::Config_info', :config_info
+    optional_param 'Optional[Dnsquery::Config_info]', :config_info
     optional_block_param :block
     return_type 'Array[Stdlib::Fqdn]'
   end

--- a/lib/puppet/functions/dnsquery/soa.rb
+++ b/lib/puppet/functions/dnsquery/soa.rb
@@ -10,7 +10,7 @@ Puppet::Functions.create_function(:'dnsquery::soa') do
   # @return The SOA record matching domain
   dispatch :dns_soa do
     param 'Stdlib::Fqdn', :question
-    optional_param 'Dnsquery::Config_info', :config_info
+    optional_param 'Optional[Dnsquery::Config_info]', :config_info
     optional_block_param :block
     return_type 'Dnsquery::Soa'
   end

--- a/lib/puppet/functions/dnsquery/srv.rb
+++ b/lib/puppet/functions/dnsquery/srv.rb
@@ -11,7 +11,7 @@ Puppet::Functions.create_function(:'dnsquery::srv') do
   dispatch :dns_srv do
     # TODO: resurrect https://github.com/puppetlabs/puppetlabs-stdlib/pull/1230
     param 'String', :domain
-    optional_param 'Dnsquery::Config_info', :config_info
+    optional_param 'Optional[Dnsquery::Config_info]', :config_info
     optional_block_param :block
     return_type 'Array[Dnsquery::Srv]'
   end

--- a/lib/puppet/functions/dnsquery/txt.rb
+++ b/lib/puppet/functions/dnsquery/txt.rb
@@ -10,7 +10,7 @@ Puppet::Functions.create_function(:'dnsquery::txt') do
   # @return The txt domain for a domain
   dispatch :dns_txt do
     param 'Stdlib::Fqdn', :domain
-    optional_param 'Dnsquery::Config_info', :config_info
+    optional_param 'Optional[Dnsquery::Config_info]', :config_info
     optional_block_param :block
     return_type 'Array[String]'
   end

--- a/spec/functions/dnsquery_lookup_spec.rb
+++ b/spec/functions/dnsquery_lookup_spec.rb
@@ -12,6 +12,12 @@ describe 'dnsquery::lookup' do
     expect(results).to all(match(matcher))
   end
 
+  it 'returns a list of addresses when doing a lookup for a single record with force_ipv6' do
+    results = subject.execute('google.com', true)
+    expect(results).to be_a Array
+    expect(results).to all(match(matcher))
+  end
+
   it 'returns a list of addresses when doing a lookup for a single record with update nameserver' do
     results = subject.execute('google.com', true, { 'nameserver' => ['8.8.8.8'] })
     expect(results).to be_a Array


### PR DESCRIPTION
We want to be able to pass an explicit nil value for the config_info parameter so that we can allow passing through that value from higher level functions e.g. lookup.

The author originally thought that optional_param would allow this behaviour however that just allows for different signature of the method and doesn't effect the type validation.  as such we need to also make the parameter type Optional[T] so that we all passing explicit nil values.

see: https://tickets.puppetlabs.com/browse/PUP-11066 
Fixes #131


